### PR TITLE
cmake: don't use kokkos directly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_subdirectory(external/Cabana)
 
+
 option(ECAB_LOCAL_ARCHITECTURE "Use instruction set of the local architecture." OFF)
 option(ECAB_VEC_REPORT "Enable reporting of loop vectorization." OFF)
 option(ECAB_WERROR "Treat warnings as errors." OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,6 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-find_package(Kokkos REQUIRED)
-
 add_subdirectory(external/Cabana)
 
 option(ECAB_LOCAL_ARCHITECTURE "Use instruction set of the local architecture." OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,6 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_subdirectory(external/Cabana)
 
-
 option(ECAB_LOCAL_ARCHITECTURE "Use instruction set of the local architecture." OFF)
 option(ECAB_VEC_REPORT "Enable reporting of loop vectorization." OFF)
 option(ECAB_WERROR "Treat warnings as errors." OFF)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(ecab main.cpp)
-target_link_libraries(ecab PRIVATE Kokkos::kokkos Cabana::cabanacore)
+target_link_libraries(ecab PRIVATE Cabana::cabanacore)
 
 if(ECAB_WERROR)
     target_compile_options(ecab PRIVATE "-Werror")


### PR DESCRIPTION
Unless you have a good reason for it, there is really no need to link kokkos directly the cabana target will take care of that.